### PR TITLE
Revert "Bump protobuf from 4.25.3 to 5.27.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ pexpect==4.9.0
 pillow==10.4.0
 platformdirs==4.2.2
 prompt_toolkit==3.0.47
-protobuf==5.27.2
+protobuf==4.25.3
 psutil==6.0.0
 ptyprocess==0.7.0
 pure-eval==0.2.3


### PR DESCRIPTION
Reverts LAB271/neural-bench#2 because
    The user requested protobuf==5.27.2
    tensorboard 2.17.0 depends on protobuf!=4.24.0, <5.0.0 and >=3.19.6